### PR TITLE
Update `hexAddrToIpStr`

### DIFF
--- a/src/collector.c
+++ b/src/collector.c
@@ -264,9 +264,9 @@ int readFile(const char *path, char *buffer[], const int bufferSize) {
 
 void hexAddrToIpStr(const char *hexAddr, char ipStr[], const int ipStrLength) {
 
-    int addrNum = (int) strtol(hexAddr, NULL, 16);
+    uint32_t addrNum = (uint32_t) strtoul(hexAddr, NULL, 16);
     struct in_addr addr;
-    addr.s_addr = htonl(addrNum); // s_addr must be in network byte order
+    addr.s_addr = addrNum; // hexAddr is in network byte order already
     char *s = inet_ntoa(addr);
 
     snprintf(ipStr, ipStrLength, "%s", s);

--- a/test/test_collector.c
+++ b/test/test_collector.c
@@ -137,8 +137,8 @@ void test_connectionsDedup(void) {
     }
 
     fileContents[0] = strcpy(fileContents[0],"sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode                                                     \n\0");
-    fileContents[1] = strcpy(fileContents[1],"    1: 00000000:170C     11111111:0000 0A 00000000:00000000 00:00000000 00000000 1420238916        0 46115 1 0000000000000000 100 0 0 10 0                 \n\0");
-    fileContents[2] = strcpy(fileContents[2],"    2: 00000000:170C     11111111:0000 0A 00000000:00000000 00:00000000 00000000 1420238916        0 46115 1 0000000000000000 100 0 0 10 0                 \n\0");
+    fileContents[1] = strcpy(fileContents[1],"    1: 00000000:170C     0100007F:0000 0A 00000000:00000000 00:00000000 00000000 1420238916        0 46115 1 0000000000000000 100 0 0 10 0                 \n\0");
+    fileContents[2] = strcpy(fileContents[2],"    2: 00000000:170C     0100007F:0000 0A 00000000:00000000 00:00000000 00000000 1420238916        0 46115 1 0000000000000000 100 0 0 10 0                 \n\0");
 
     NetworkConnection connList[DUMMY_FILE_LINES];
     int connCount = 0;
@@ -155,7 +155,7 @@ void test_connectionsDedup(void) {
 
     TEST_ASSERT_EQUAL_STRING("0.0.0.0",connList[0].localAddress);
     TEST_ASSERT_EQUAL_STRING("5900",connList[0].localPort);
-    TEST_ASSERT_EQUAL_STRING("17.17.17.17",connList[0].remoteAddress);
+    TEST_ASSERT_EQUAL_STRING("127.0.0.1",connList[0].remoteAddress);
     TEST_ASSERT_EQUAL(connList[0].connectionState,LISTEN);
 
      for(int i=0; i< DUMMY_FILE_LINES; i++) {
@@ -200,7 +200,7 @@ void test_uniqueConnections() {
 void test_hexStringToIpString(void) {
     char ipStr[MAX_IP_ADDR_STRING_LENGTH];
     hexAddrToIpStr("6BA44E0A",ipStr,MAX_IP_ADDR_STRING_LENGTH);
-    TEST_ASSERT_EQUAL_STRING("107.164.78.10",ipStr);
+    TEST_ASSERT_EQUAL_STRING("10.78.164.107",ipStr);
  }
 
 void test_hexPortToTcpPort(void) {
@@ -256,7 +256,7 @@ void test_getUDPConnectionsBasic(void) {
        TEST_ASSERT_EQUAL_STRING("0.0.0.0",connections[i].remoteAddress);
        TEST_ASSERT_EQUAL_STRING("0",connections[i].remotePort);
 
-       if(strcmp("53.166.78.10",connections[i].localAddress) == 0) {
+       if(strcmp("10.78.166.53",connections[i].localAddress) == 0) {
            if(strcmp("45775",connections[i].localPort) == 0) {
                found = true;
            }


### PR DESCRIPTION
*Description of changes:* 
`hexAddrToIpStr` generates incorrect values, the file `/proc/net/tcp` has its addresses in the network format already.

The current tests had symmetric addresses hiding the issue. It is now updated to `localhost`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
