### PR TITLE
Use a UNIX timestamp for report id

### DIFF
--- a/src/collector.c
+++ b/src/collector.c
@@ -364,8 +364,11 @@ void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *
     metrics.tcpConnectionCount = establishedCount;
     metrics.networkStats = stats;
 
-    //TODO Generate a real report ID
-    struct Header header = {12312312, "1.0"};
+    //generate UNIX timestamp for report ID
+    time_t seconds;
+    seconds = time(NULL);
+
+    struct Header header = {seconds, "1.0"};
 
     struct Report report;
     report.header = header;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Generate a UNIX epoch timestamp for report header, ensuring that each report ID is a monotonically increasing value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
