### PR TITLE
fix incorrect network metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ git clone https://github.com/aws-samples/aws-iot-device-defender-agent-c.git
    cd scripts
    ./bootstrap.sh
    ```
+3. This program also uses zlib, a data compression library. To install,
+   ```
+   wget http://www.zlib.net/zlib-1.2.12.tar.gz
+   tar -xvzf zlib-1.2.12.tar.gz
+   cd zlib-1.2.12
+   ./configure --prefix=/usr/local/zlib
+   make install
+   ```
+   or use a package manager.
 
 #### Configure the SDK with your device parameters
 

--- a/src/collector.c
+++ b/src/collector.c
@@ -225,11 +225,15 @@ void parseNetDev(char **fileContents, int fileLines, NetworkStats *stats) {
         }
     }
 
-    (*stats).bytesIn = bytesIn;
-    (*stats).bytesOut = bytesOut;
-    (*stats).packetsIn = packetsIn;
-    (*stats).packetsOut = packetsOut;
+    stats->bytesInDelta = bytesIn - stats->bytesInPrev;
+    stats->bytesOutDelta = bytesOut - stats->bytesOutPrev;
+    stats->packetsInDelta = packetsIn - stats->packetsInPrev;
+    stats->packetsOutDelta = packetsOut - stats->packetsOutPrev;
 
+    stats->bytesInPrev = bytesIn;
+    stats->bytesOutPrev = bytesOut;
+    stats->packetsInPrev = packetsIn;
+    stats->packetsOutPrev = packetsOut;
     return;
 }
 
@@ -326,13 +330,12 @@ filterTCPConnectionsByState(enum state status, const NetworkConnection allConnec
 }
 
 
-void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *reportSize, enum tagType tagLen,
+void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *reportSize, NetworkStats *stats, enum tagType tagLen,
                            enum format reportFormat) {
 
     printf("Using file: %s\n", PROC_NET_DEV);
 
-    NetworkStats stats;
-    getNetworkStats(PROC_NET_DEV, &stats);
+    getNetworkStats(PROC_NET_DEV, stats);
 
     NetworkConnection tcpConnections[MAX_CONNECTIONS];
     int tcpConnectionCount = 0;
@@ -362,7 +365,7 @@ void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *
     metrics.udpPortCount = udpConnectionCount;
     metrics.tcpConnections = establishedConnections;
     metrics.tcpConnectionCount = establishedCount;
-    metrics.networkStats = stats;
+    metrics.networkStats = *stats;
 
     //generate UNIX timestamp for report ID
     time_t seconds;

--- a/src/collector.h
+++ b/src/collector.h
@@ -141,9 +141,10 @@ filterTCPConnectionsByState(enum state status, const NetworkConnection allConnec
  * @param [in] reportFormat
  * @param [out] reportBuffer String to hold full report
  * @param [in] reportBufferSize Maximum length of the final report
+ * @param [out] stats Network stats struct
  * @param [in] tagLen Use Long or Short names
  */
-void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *reportSize, enum tagType tagLen,
+void generateMetricsReport(char *reportBuffer, const int reportBufferSize, int *reportSize, NetworkStats *stats, enum tagType tagLen,
                            enum format reportFormat);
 
 /**

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -92,8 +92,8 @@ void printReportToConsole(const struct Report *report) {
 
     NetworkStats s = m.networkStats;
     printf("\tNetwork Stats\n");
-    printf("\t\tBytes in/out: %lu/%lu\n", s.bytesIn, s.bytesOut);
-    printf("\t\tPackets in/out: %lu/%lu\n", s.packetsIn, s.packetsOut);
+    printf("\t\tBytes in/out: %lu/%lu\n", s.bytesInDelta, s.bytesOutDelta);
+    printf("\t\tPackets in/out: %lu/%lu\n", s.packetsInDelta, s.packetsOutDelta);
 
 }
 
@@ -156,10 +156,10 @@ void generateJSONReport(const struct Report *rpt, char *json, int *length, enum 
 
     //Network Stats
     cJSON *stats = cJSON_CreateObject();
-    cJSON_AddNumberToObject(stats, t->BYTES_IN, rpt->metrics.networkStats.bytesIn);
-    cJSON_AddNumberToObject(stats, t->BYTES_OUT, rpt->metrics.networkStats.bytesOut);
-    cJSON_AddNumberToObject(stats, t->PACKETS_IN, rpt->metrics.networkStats.packetsIn);
-    cJSON_AddNumberToObject(stats, t->PACKETS_OUT, rpt->metrics.networkStats.packetsOut);
+    cJSON_AddNumberToObject(stats, t->BYTES_IN, rpt->metrics.networkStats.bytesInDelta);
+    cJSON_AddNumberToObject(stats, t->BYTES_OUT, rpt->metrics.networkStats.bytesOutDelta);
+    cJSON_AddNumberToObject(stats, t->PACKETS_IN, rpt->metrics.networkStats.packetsInDelta);
+    cJSON_AddNumberToObject(stats, t->PACKETS_OUT, rpt->metrics.networkStats.packetsOutDelta);
     cJSON_AddItemToObject(metrics, t->NETWORK_STATS, stats);
 
     //TCP Connections
@@ -296,31 +296,31 @@ void generateCBORReport(const struct Report *rpt, char *cbor, int *length, enum 
     }
 
     //Network Stats
-    if (rpt->metrics.networkStats.packetsOut > 0 || rpt->metrics.networkStats.bytesOut > 0
-        || rpt->metrics.networkStats.packetsIn > 0 || rpt->metrics.networkStats.bytesIn > 0) {
+    if (rpt->metrics.networkStats.packetsOutDelta > 0 || rpt->metrics.networkStats.bytesOutDelta > 0
+        || rpt->metrics.networkStats.packetsInDelta > 0 || rpt->metrics.networkStats.bytesInDelta > 0) {
 
         CborEncoder netStats;
         cbor_encode_text_stringz(&metrics, t->NETWORK_STATS);
         cbor_encoder_create_map(&metrics, &netStats, CborIndefiniteLength);
 
-        if (rpt->metrics.networkStats.bytesIn > 0) {
+        if (rpt->metrics.networkStats.bytesInDelta > 0) {
             cbor_encode_text_stringz(&netStats, t->BYTES_IN);
-            cbor_encode_int(&netStats, rpt->metrics.networkStats.bytesIn);
+            cbor_encode_int(&netStats, rpt->metrics.networkStats.bytesInDelta);
         }
 
-        if (rpt->metrics.networkStats.bytesOut > 0) {
+        if (rpt->metrics.networkStats.bytesOutDelta > 0) {
             cbor_encode_text_stringz(&netStats, t->BYTES_OUT);
-            cbor_encode_int(&netStats, rpt->metrics.networkStats.bytesOut);
+            cbor_encode_int(&netStats, rpt->metrics.networkStats.bytesOutDelta);
         }
 
-        if (rpt->metrics.networkStats.packetsIn > 0) {
+        if (rpt->metrics.networkStats.packetsInDelta > 0) {
             cbor_encode_text_stringz(&netStats, t->PACKETS_IN);
-            cbor_encode_int(&netStats, rpt->metrics.networkStats.packetsIn);
+            cbor_encode_int(&netStats, rpt->metrics.networkStats.packetsInDelta);
         }
 
-        if (rpt->metrics.networkStats.packetsOut > 0) {
+        if (rpt->metrics.networkStats.packetsOutDelta > 0) {
             cbor_encode_text_stringz(&netStats, t->PACKETS_OUT);
-            cbor_encode_int(&netStats, rpt->metrics.networkStats.packetsOut);
+            cbor_encode_int(&netStats, rpt->metrics.networkStats.packetsOutDelta);
         }
 
         cbor_encoder_close_container(&metrics, &netStats);

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -46,10 +46,14 @@ enum protocol {
  */
 typedef struct {
     char *interface; /** Network Interface Name */
-    unsigned long bytesIn;
-    unsigned long bytesOut;
-    unsigned long packetsIn;
-    unsigned long packetsOut;
+    unsigned long bytesInPrev;
+    unsigned long bytesOutPrev;
+    unsigned long packetsInPrev;
+    unsigned long packetsOutPrev;
+    unsigned long bytesInDelta;
+    unsigned long bytesOutDelta;
+    unsigned long packetsInDelta;
+    unsigned long packetsOutDelta;
 } NetworkStats;
 
 typedef struct {

--- a/test/test_metrics.c
+++ b/test/test_metrics.c
@@ -61,7 +61,8 @@ void test_JSONMetricsBasicStructure_LongTags() {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, LONG_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, LONG_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -100,7 +101,8 @@ void test_JSONMetricsBasicStructure_ShortTags() {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, SHORT_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, SHORT_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -139,7 +141,8 @@ void test_tcpPortsListJSON_LongTags(void) {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, LONG_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, LONG_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -163,7 +166,8 @@ void test_tcpPortsListJSON_ShortTags(void) {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, SHORT_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, SHORT_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -187,7 +191,8 @@ void test_udpPortsListJSON_LongTags(void) {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, LONG_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, LONG_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -211,7 +216,8 @@ void test_udpPortsListJSON_ShortTags(void) {
 
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, SHORT_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, SHORT_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -234,7 +240,12 @@ void test_udpPortsListJSON_ShortTags(void) {
 void test_netstatsJSON_LongTags(void) {
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, LONG_NAMES, JSON);
+    NetworkStats stats;
+    stats.bytesInPrev = 1;
+    stats.packetsInPrev = 1;
+    stats.bytesOutPrev = 1;
+    stats.packetsOutPrev = 1;
+    generateMetricsReport(reportString, 128000, &length, &stats, LONG_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -256,7 +267,12 @@ void test_netstatsJSON_LongTags(void) {
 void test_netstatsJSON_ShortTags(void) {
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, SHORT_NAMES, JSON);
+    NetworkStats stats;
+    stats.bytesInPrev = 1;
+    stats.packetsInPrev = 1;
+    stats.bytesOutPrev = 1;
+    stats.packetsOutPrev = 1;
+    generateMetricsReport(reportString, 128000, &length, &stats, SHORT_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -279,7 +295,8 @@ void test_netstatsJSON_ShortTags(void) {
 void test_tcpConnectionsJSON_LongTags(void) {
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, LONG_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, LONG_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -303,7 +320,8 @@ void test_tcpConnectionsJSON_LongTags(void) {
 void test_tcpConnectionsJSON_ShortTags(void) {
     char reportString[128000];
     int length = -1;
-    generateMetricsReport(reportString, 128000, &length, SHORT_NAMES, JSON);
+    NetworkStats stats;
+    generateMetricsReport(reportString, 128000, &length, &stats, SHORT_NAMES, JSON);
 
     //Basic Structure
     cJSON *report = cJSON_Parse(reportString);
@@ -327,7 +345,8 @@ void test_tcpConnectionsJSON_ShortTags(void) {
 void test_reportCBOR_BasicStructure_LongTags(void) {
     uint8_t reportBuffer[512000];
     int length = -1;
-    generateMetricsReport(reportBuffer, 512000, &length, LONG_NAMES, CBOR);
+    NetworkStats stats;
+    generateMetricsReport(reportBuffer, 512000, &length, &stats, LONG_NAMES, CBOR);
 
     TEST_ASSERT_GREATER_OR_EQUAL(1,strlen(reportBuffer));
     TEST_ASSERT_GREATER_OR_EQUAL(1,length);
@@ -363,7 +382,8 @@ void test_reportCBOR_BasicStructure_LongTags(void) {
 void test_reportCBOR_header_LongTags(void) {
     uint8_t reportBuffer[512000];
     int length = -1;
-    generateMetricsReport(reportBuffer, 512000, &length, LONG_NAMES, CBOR);
+    NetworkStats stats;
+    generateMetricsReport(reportBuffer, 512000, &length, &stats, LONG_NAMES, CBOR);
 
     TEST_ASSERT_GREATER_OR_EQUAL(1,strlen(reportBuffer));
     TEST_ASSERT_GREATER_OR_EQUAL(1,length);
@@ -411,7 +431,8 @@ void test_reportCBOR_header_LongTags(void) {
 void test_reportCBOR_metrics_LongTags(void) {
     uint8_t reportBuffer[512000];
     int length = -1;
-    generateMetricsReport(reportBuffer, 512000, &length, LONG_NAMES, CBOR);
+    NetworkStats stats;
+    generateMetricsReport(reportBuffer, 512000, &length, &stats, LONG_NAMES, CBOR);
 
     TEST_ASSERT_GREATER_OR_EQUAL(1,strlen(reportBuffer));
     TEST_ASSERT_GREATER_OR_EQUAL(1,length);


### PR DESCRIPTION
*Issue #, if available:*

#6 

*Description of changes:*

The agent will no longer publish network metrics immediately upon startup when a delta cannot be calculated. It should now correctly calculate network throughput for every interval.

Added a test and modified existing tests to work with the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
